### PR TITLE
Fix: Use vercel build instead of pnpm build for prebuilt deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,10 +60,12 @@ jobs:
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: apps/docs
 
-      - name: Build Project
-        run: pnpm run build
+      - name: Build Project with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           NODE_ENV: production
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy Project to Vercel
         id: vercel-deploy

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,8 +1,8 @@
 {
-  "buildCommand": "npm install && npm run build",
+  "buildCommand": "pnpm install && pnpm run build",
   "outputDirectory": "build",
-  "devCommand": "npm start",
-  "installCommand": "npm install",
+  "devCommand": "pnpm start",
+  "installCommand": "pnpm install",
   "framework": null,
   "rewrites": [
     {


### PR DESCRIPTION
- Replace pnpm run build with vercel build --prod to generate .vercel/output
- Update vercel.json to use pnpm instead of npm
- This ensures --prebuilt option works correctly